### PR TITLE
initialize: Hyperledger Fabric network setup with Docker Compose

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -37,6 +37,7 @@ services:
     ports:
       - 7050:7050
     volumes:
+      - ./channel-artifacts:/var/hyperledger/orderer
       - ./crypto-config/ordererOrganizations/example.com/orderers/orderer.example.com/:/var/hyperledger/orderer
     networks:
       - fabric-network

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,75 +1,39 @@
 version: '2'
 
-volumes:
-  orderer.example.com:
-  peer0.org1.example.com:
-
 networks:
-  fabric-network:
+  basic:
 
 services:
-  ca.org1.example.com:
-    image: hyperledger/fabric-ca:latest
-    environment:
-      - FABRIC_CA_HOME=/etc/hyperledger/fabric-ca-server
-      - FABRIC_CA_SERVER_CA_NAME=ca.org1.example.com
-      - FABRIC_CA_SERVER_TLS_ENABLED=false
-      - FABRIC_CA_SERVER_DB_TYPE=sqlite3
-      - FABRIC_CA_SERVER_DB_DATASOURCE=/etc/hyperledger/fabric-ca-server/fabric-ca-server.db
-    ports:
-      - "7054:7054"
-    command: sh -c 'fabric-ca-server start -b admin:adminpw'
-    networks:
-      - fabric-network
-
   orderer.example.com:
+    container_name: orderer.example.com
     image: hyperledger/fabric-orderer:latest
     environment:
-      - ORDERER_GENERAL_LOGLEVEL=info
       - ORDERER_GENERAL_LISTENADDRESS=0.0.0.0
-      - ORDERER_GENERAL_GENESISMETHOD=file
-      - ORDERER_GENERAL_GENESISFILE=/var/hyperledger/orderer/orderer.genesis.block
-      - ORDERER_GENERAL_LOCALMSPID=OrdererMSP
-      - ORDERER_GENERAL_LOCALMSPDIR=/var/hyperledger/orderer/msp
       - ORDERER_GENERAL_TLS_ENABLED=false
-    working_dir: /opt/gopath/src/github.com/hyperledger/fabric
-    command: orderer
     ports:
-      - 7050:7050
-    volumes:
-      - ./channel-artifacts:/var/hyperledger/orderer
-      - ./crypto-config/ordererOrganizations/example.com/orderers/orderer.example.com/:/var/hyperledger/orderer
+      - "7050:7050"
     networks:
-      - fabric-network
+      - basic
 
   peer0.org1.example.com:
+    container_name: peer0.org1.example.com
     image: hyperledger/fabric-peer:latest
     environment:
-      - CORE_VM_ENDPOINT=unix:///host/var/run/docker.sock
       - CORE_PEER_ID=peer0.org1.example.com
-      - CORE_LOGGING_PEER=info
-      - CORE_CHAINCODE_LOGGING_LEVEL=info
-      - CORE_PEER_LOCALMSPID=Org1MSP
-      - CORE_PEER_MSPCONFIGPATH=/etc/hyperledger/peer/msp
       - CORE_PEER_ADDRESS=peer0.org1.example.com:7051
-      - CORE_PEER_CHAINCODEADDRESS=peer0.org1.example.com:7052
-      - CORE_PEER_CHAINCODELISTENADDRESS=0.0.0.0:7052
-      - CORE_PEER_GOSSIP_EXTERNALENDPOINT=peer0.org1.example.com:7051
-      - CORE_PEER_GOSSIP_BOOTSTRAP=peer0.org1.example.com:7051
+      - CORE_PEER_LOCALMSPID=Org1MSP
       - CORE_PEER_TLS_ENABLED=false
+      - CORE_VM_ENDPOINT=unix:///host/var/run/docker.sock
       - CORE_CHAINCODE_EXTERNALBUILD=true
       - CORE_CHAINCODE_EXECUTABLE=com.founderz.chaincode.FounderzAgreementChainCode
-    working_dir: /opt/gopath/src/github.com/hyperledger/fabric/peer
-    command: peer node start
-    ports:
-      - 7051:7051
-      - 7053:7053
+      - CORE_CHAINCODE_JAVA_RUNTIME=java:11
     volumes:
       - /var/run/:/host/var/run/
-      - ./crypto-config/peerOrganizations/org1.example.com/peers/peer0.org1.example.com/msp:/etc/hyperledger/peer/msp
-      - ./crypto-config/peerOrganizations/org1.example.com/users:/etc/hyperledger/msp/users
       - ./src/main/java:/opt/gopath/src/github.com/chaincode
+    ports:
+      - "7051:7051"
+      - "7052:7052"
+    networks:
+      - basic
     depends_on:
       - orderer.example.com
-    networks:
-      - fabric-network

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -14,6 +14,8 @@ services:
       - FABRIC_CA_HOME=/etc/hyperledger/fabric-ca-server
       - FABRIC_CA_SERVER_CA_NAME=ca.org1.example.com
       - FABRIC_CA_SERVER_TLS_ENABLED=false
+      - FABRIC_CA_SERVER_DB_TYPE=sqlite3
+      - FABRIC_CA_SERVER_DB_DATASOURCE=/etc/hyperledger/fabric-ca-server/fabric-ca-server.db
     ports:
       - "7054:7054"
     command: sh -c 'fabric-ca-server start -b admin:adminpw'

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -31,8 +31,6 @@ services:
       - ORDERER_GENERAL_GENESISFILE=/var/hyperledger/orderer/orderer.genesis.block
       - ORDERER_GENERAL_LOCALMSPID=OrdererMSP
       - ORDERER_GENERAL_LOCALMSPDIR=/var/hyperledger/orderer/msp
-      - ORDERER_KAFKA_TOPIC_REPLICATIONFACTOR=1
-      - ORDERER_KAFKA_VERBOSE=true
       - ORDERER_GENERAL_TLS_ENABLED=false
     working_dir: /opt/gopath/src/github.com/hyperledger/fabric
     command: orderer

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,7 +6,7 @@ networks:
 services:
   orderer.example.com:
     container_name: orderer.example.com
-    image: hyperledger/fabric-orderer:latest
+    image: hyperledger/fabric-orderer:2.5.0
     environment:
       - ORDERER_GENERAL_LISTENADDRESS=0.0.0.0
       - ORDERER_GENERAL_TLS_ENABLED=false
@@ -17,7 +17,7 @@ services:
 
   peer0.org1.example.com:
     container_name: peer0.org1.example.com
-    image: hyperledger/fabric-peer:latest
+    image: hyperledger/fabric-peer:2.5.0
     environment:
       - CORE_PEER_ID=peer0.org1.example.com
       - CORE_PEER_ADDRESS=peer0.org1.example.com:7051

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -26,7 +26,7 @@ services:
       - CORE_VM_ENDPOINT=unix:///host/var/run/docker.sock
       - CORE_CHAINCODE_EXTERNALBUILD=true
       - CORE_CHAINCODE_EXECUTABLE=com.founderz.chaincode.FounderzAgreementChainCode
-      - CORE_CHAINCODE_JAVA_RUNTIME=java:11
+      - CORE_CHAINCODE_JAVA_RUNTIME=java:21
     volumes:
       - /var/run/:/host/var/run/
       - ./src/main/java:/opt/gopath/src/github.com/chaincode

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,74 @@
+version: '2'
+
+volumes:
+  orderer.example.com:
+  peer0.org1.example.com:
+
+networks:
+  fabric-network:
+
+services:
+  ca.org1.example.com:
+    image: hyperledger/fabric-ca:latest
+    environment:
+      - FABRIC_CA_HOME=/etc/hyperledger/fabric-ca-server
+      - FABRIC_CA_SERVER_CA_NAME=ca.org1.example.com
+      - FABRIC_CA_SERVER_TLS_ENABLED=false
+    ports:
+      - "7054:7054"
+    command: sh -c 'fabric-ca-server start -b admin:adminpw'
+    networks:
+      - fabric-network
+
+  orderer.example.com:
+    image: hyperledger/fabric-orderer:latest
+    environment:
+      - ORDERER_GENERAL_LOGLEVEL=info
+      - ORDERER_GENERAL_LISTENADDRESS=0.0.0.0
+      - ORDERER_GENERAL_GENESISMETHOD=file
+      - ORDERER_GENERAL_GENESISFILE=/var/hyperledger/orderer/orderer.genesis.block
+      - ORDERER_GENERAL_LOCALMSPID=OrdererMSP
+      - ORDERER_GENERAL_LOCALMSPDIR=/var/hyperledger/orderer/msp
+      - ORDERER_KAFKA_TOPIC_REPLICATIONFACTOR=1
+      - ORDERER_KAFKA_VERBOSE=true
+      - ORDERER_GENERAL_TLS_ENABLED=false
+    working_dir: /opt/gopath/src/github.com/hyperledger/fabric
+    command: orderer
+    ports:
+      - 7050:7050
+    volumes:
+      - ./crypto-config/ordererOrganizations/example.com/orderers/orderer.example.com/:/var/hyperledger/orderer
+    networks:
+      - fabric-network
+
+  peer0.org1.example.com:
+    image: hyperledger/fabric-peer:latest
+    environment:
+      - CORE_VM_ENDPOINT=unix:///host/var/run/docker.sock
+      - CORE_PEER_ID=peer0.org1.example.com
+      - CORE_LOGGING_PEER=info
+      - CORE_CHAINCODE_LOGGING_LEVEL=info
+      - CORE_PEER_LOCALMSPID=Org1MSP
+      - CORE_PEER_MSPCONFIGPATH=/etc/hyperledger/peer/msp
+      - CORE_PEER_ADDRESS=peer0.org1.example.com:7051
+      - CORE_PEER_CHAINCODEADDRESS=peer0.org1.example.com:7052
+      - CORE_PEER_CHAINCODELISTENADDRESS=0.0.0.0:7052
+      - CORE_PEER_GOSSIP_EXTERNALENDPOINT=peer0.org1.example.com:7051
+      - CORE_PEER_GOSSIP_BOOTSTRAP=peer0.org1.example.com:7051
+      - CORE_PEER_TLS_ENABLED=false
+      - CORE_CHAINCODE_EXTERNALBUILD=true
+      - CORE_CHAINCODE_EXECUTABLE=com.founderz.chaincode.FounderzAgreementChainCode
+    working_dir: /opt/gopath/src/github.com/hyperledger/fabric/peer
+    command: peer node start
+    ports:
+      - 7051:7051
+      - 7053:7053
+    volumes:
+      - /var/run/:/host/var/run/
+      - ./crypto-config/peerOrganizations/org1.example.com/peers/peer0.org1.example.com/msp:/etc/hyperledger/peer/msp
+      - ./crypto-config/peerOrganizations/org1.example.com/users:/etc/hyperledger/msp/users
+      - ./src/main/java:/opt/gopath/src/github.com/chaincode
+    depends_on:
+      - orderer.example.com
+    networks:
+      - fabric-network


### PR DESCRIPTION
Hyperledger Fabric 네트워크 환경 설정을 위한 docker compose 파일을 작성했습니다.

### 주요 내용.
- Fabric의 피어와 관련된 서비스 및 체인코드 경로 정의.
- Docker 컨테이너 내에서 Hyperledger Fabric의 피어, 체인코드 등이 실행되도록 구성.
- 로컬 개발 환경에서 Hyperledger Fabric 네트워크를 시작할 수 있도록 설정.

### 참고 문헌
- https://hyperledger-fabric.readthedocs.io/en/latest/network/network.html
- https://github.com/hyperledger/fabric-samples
- https://velog.io/@jaehyuen/Hyperledger-Fabric-2.2-%EC%8B%A4%EC%8A%B5-4-Fabric-Orderer-Peer-%EA%B5%AC%EC%B6%95